### PR TITLE
Port date parsing fix from Swift 4

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift5/CodableHelper.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/CodableHelper.mustache
@@ -9,6 +9,10 @@ import Foundation
 
 public typealias EncodeResult = (data: Data?, error: Error?)
 
+enum DateError: String, Error {
+    case invalidDate
+}
+
 open class CodableHelper {
 
     public static var dateformatter: DateFormatter?
@@ -22,12 +26,33 @@ open class CodableHelper {
             decoder.dateDecodingStrategy = .formatted(df)
         } else {
             decoder.dataDecodingStrategy = .base64
-            let formatter = DateFormatter()
-            formatter.calendar = Calendar(identifier: .iso8601)
-            formatter.locale = Locale(identifier: "en_US_POSIX")
-            formatter.timeZone = TimeZone(secondsFromGMT: 0)
-            formatter.dateFormat = Configuration.dateFormat
-            decoder.dateDecodingStrategy = .formatted(formatter)
+            decoder.dateDecodingStrategy = .custom({ (decoder) -> Date in
+                let container = try decoder.singleValueContainer()
+                let dateStr = try container.decode(String.self)
+
+                let formatters = [
+                    "yyyy-MM-dd",
+                    "yyyy-MM-dd'T'HH:mm:ssZZZZZ",
+                    "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ",
+                    "yyyy-MM-dd'T'HH:mm:ss'Z'",
+                    "yyyy-MM-dd'T'HH:mm:ss.SSS",
+                    "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+                    "yyyy-MM-dd HH:mm:ss"
+                    ].map { (format: String) -> DateFormatter in
+                        let formatter = DateFormatter()
+                        formatter.locale = Locale(identifier: "en_US_POSIX")
+                        formatter.dateFormat = format
+                        return formatter
+                }
+
+                for formatter in formatters {
+                    if let date = formatter.date(from: dateStr) {
+                        return date
+                    }
+                }
+
+                throw DateError.invalidDate
+            })
         }
 
         do {


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

This ports a date parsing fix from Swagger-Codegen: https://github.com/swagger-api/swagger-codegen/pull/9730

### Description

This is a fix that was originally merged into the swagger-codegen repo ([original PR](https://github.com/swagger-api/swagger-codegen/pull/9730)). A PR to bring the same fix to Swift 4 has being done to the openapi-generator repo.